### PR TITLE
fix: unblock dependency security audits

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@tauri-apps/cli": "^2.10.0",
-    "@vitest/coverage-v8": "^3.2.4",
+    "@vitest/coverage-v8": "^3.2.6",
     "@types/leaflet": "^1.9.21",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
@@ -82,7 +82,7 @@
     "tailwindcss": "^4.1.18",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "7.3.2",
+    "vite": "7.3.5",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@commitlint/cz-commitlint": "^19.8.1",
@@ -92,27 +92,11 @@
     "lint-staged": "^15.5.2",
     "prettier": "^3.6.2",
     "jsdom": "^26.1.0",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.6"
   },
   "config": {
     "commitizen": {
       "path": "@commitlint/cz-commitlint"
-    }
-  },
-  "pnpm": {
-    "overrides": {
-      "basic-ftp": "5.3.1",
-      "fast-uri": "3.1.2",
-      "flatted": "3.4.2",
-      "lodash": "4.18.0",
-      "lodash-es": "4.18.0",
-      "minimatch@<3.1.4": "3.1.4",
-      "minimatch@>=9.0.0 <9.0.7": "9.0.7",
-      "path-to-regexp": "0.1.13",
-      "picomatch@<2.3.2": "2.3.2",
-      "picomatch@>=4.0.0 <4.0.4": "4.0.4",
-      "rollup@<4.59.0": "4.59.0",
-      "vite@>=7.1.0 <=7.3.1": "7.3.2"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,10 @@ overrides:
   picomatch@<2.3.2: 2.3.2
   picomatch@>=4.0.0 <4.0.4: 4.0.4
   rollup@<4.59.0: 4.59.0
-  vite@>=7.1.0 <=7.3.1: 7.3.2
+  vite@>=7.1.0 <=7.3.4: 7.3.5
+  tmp@<0.2.7: 0.2.7
+  ws@>=7.0.0 <7.5.11: 7.5.11
+  ws@>=8.0.0 <8.21.0: 8.21.0
 
 importers:
   .:
@@ -69,7 +72,7 @@ importers:
         version: 1.58.2
       "@tailwindcss/vite":
         specifier: ^4.1.18
-        version: 4.1.18(vite@7.3.2(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        version: 4.1.18(vite@7.3.5(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
       "@tauri-apps/cli":
         specifier: ^2.10.0
         version: 2.10.0
@@ -96,10 +99,10 @@ importers:
         version: 19.2.3(@types/react@19.2.13)
       "@vitejs/plugin-react":
         specifier: ^5.1.1
-        version: 5.1.3(vite@7.3.2(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        version: 5.1.3(vite@7.3.5(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
       "@vitest/coverage-v8":
-        specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2))
+        specifier: ^3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2))
       commitizen:
         specifier: ^4.3.1
         version: 4.3.1(@types/node@24.10.11)(typescript@5.9.3)
@@ -137,11 +140,11 @@ importers:
         specifier: ^8.46.4
         version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
-        specifier: 7.3.2
-        version: 7.3.2(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+        specifier: 7.3.5
+        version: 7.3.5(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2)
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2)
 
 packages:
   "@adobe/css-tools@4.4.4":
@@ -1405,7 +1408,7 @@ packages:
         integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==,
       }
     peerDependencies:
-      vite: 7.3.2
+      vite: 7.3.5
 
   "@tauri-apps/api@2.10.1":
     resolution:
@@ -1766,68 +1769,68 @@ packages:
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     peerDependencies:
-      vite: 7.3.2
+      vite: 7.3.5
 
-  "@vitest/coverage-v8@3.2.4":
+  "@vitest/coverage-v8@3.2.6":
     resolution:
       {
-        integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==,
+        integrity: sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==,
       }
     peerDependencies:
-      "@vitest/browser": 3.2.4
-      vitest: 3.2.4
+      "@vitest/browser": 3.2.6
+      vitest: 3.2.6
     peerDependenciesMeta:
       "@vitest/browser":
         optional: true
 
-  "@vitest/expect@3.2.4":
+  "@vitest/expect@3.2.6":
     resolution:
       {
-        integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==,
+        integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==,
       }
 
-  "@vitest/mocker@3.2.4":
+  "@vitest/mocker@3.2.6":
     resolution:
       {
-        integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==,
+        integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==,
       }
     peerDependencies:
       msw: ^2.4.9
-      vite: 7.3.2
+      vite: 7.3.5
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  "@vitest/pretty-format@3.2.4":
+  "@vitest/pretty-format@3.2.6":
     resolution:
       {
-        integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==,
+        integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==,
       }
 
-  "@vitest/runner@3.2.4":
+  "@vitest/runner@3.2.6":
     resolution:
       {
-        integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==,
+        integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==,
       }
 
-  "@vitest/snapshot@3.2.4":
+  "@vitest/snapshot@3.2.6":
     resolution:
       {
-        integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==,
+        integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==,
       }
 
-  "@vitest/spy@3.2.4":
+  "@vitest/spy@3.2.6":
     resolution:
       {
-        integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==,
+        integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==,
       }
 
-  "@vitest/utils@3.2.4":
+  "@vitest/utils@3.2.6":
     resolution:
       {
-        integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==,
+        integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==,
       }
 
   JSONStream@1.3.5:
@@ -4725,13 +4728,6 @@ packages:
       }
     engines: { node: ">=10" }
 
-  os-tmpdir@1.0.2:
-    resolution:
-      {
-        integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==,
-      }
-    engines: { node: ">=0.10.0" }
-
   p-limit@2.3.0:
     resolution:
       {
@@ -5168,14 +5164,6 @@ packages:
       {
         integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
       }
-
-  rimraf@2.7.1:
-    resolution:
-      {
-        integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==,
-      }
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
 
   rimraf@3.0.2:
     resolution:
@@ -5725,19 +5713,12 @@ packages:
       }
     hasBin: true
 
-  tmp@0.0.33:
+  tmp@0.2.7:
     resolution:
       {
-        integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==,
+        integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==,
       }
-    engines: { node: ">=0.6.0" }
-
-  tmp@0.1.0:
-    resolution:
-      {
-        integrity: sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==,
-      }
-    engines: { node: ">=6" }
+    engines: { node: ">=14.14" }
 
   to-regex-range@5.0.1:
     resolution:
@@ -5949,10 +5930,10 @@ packages:
     engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
     hasBin: true
 
-  vite@7.3.2:
+  vite@7.3.5:
     resolution:
       {
-        integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==,
+        integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
@@ -5992,10 +5973,10 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.2.4:
+  vitest@3.2.6:
     resolution:
       {
-        integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==,
+        integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==,
       }
     engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
     hasBin: true
@@ -6003,8 +5984,8 @@ packages:
       "@edge-runtime/vm": "*"
       "@types/debug": ^4.1.12
       "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
-      "@vitest/browser": 3.2.4
-      "@vitest/ui": 3.2.4
+      "@vitest/browser": 3.2.6
+      "@vitest/ui": 3.2.6
       happy-dom: "*"
       jsdom: "*"
     peerDependenciesMeta:
@@ -6165,10 +6146,10 @@ packages:
         integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==,
       }
 
-  ws@7.5.10:
+  ws@7.5.11:
     resolution:
       {
-        integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==,
+        integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==,
       }
     engines: { node: ">=8.3.0" }
     peerDependencies:
@@ -6180,10 +6161,10 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.19.0:
+  ws@8.21.0:
     resolution:
       {
-        integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==,
+        integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==,
       }
     engines: { node: ">=10.0.0" }
     peerDependencies:
@@ -6869,7 +6850,7 @@ snapshots:
       lighthouse-logger: 1.2.0
       open: 7.4.2
       proxy-agent: 6.5.0
-      tmp: 0.1.0
+      tmp: 0.2.7
       uuid: 8.3.2
       yargs: 15.4.1
       yargs-parser: 13.1.2
@@ -7104,12 +7085,12 @@ snapshots:
       "@tailwindcss/oxide-win32-arm64-msvc": 4.1.18
       "@tailwindcss/oxide-win32-x64-msvc": 4.1.18
 
-  "@tailwindcss/vite@4.1.18(vite@7.3.2(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))":
+  "@tailwindcss/vite@4.1.18(vite@7.3.5(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))":
     dependencies:
       "@tailwindcss/node": 4.1.18
       "@tailwindcss/oxide": 4.1.18
       tailwindcss: 4.1.18
-      vite: 7.3.2(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.5(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
   "@tauri-apps/api@2.10.1": {}
 
@@ -7348,7 +7329,7 @@ snapshots:
       "@typescript-eslint/types": 8.54.0
       eslint-visitor-keys: 4.2.1
 
-  "@vitejs/plugin-react@5.1.3(vite@7.3.2(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))":
+  "@vitejs/plugin-react@5.1.3(vite@7.3.5(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/plugin-transform-react-jsx-self": 7.27.1(@babel/core@7.29.0)
@@ -7356,11 +7337,11 @@ snapshots:
       "@rolldown/pluginutils": 1.0.0-rc.2
       "@types/babel__core": 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.2(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.5(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  "@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2))":
+  "@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2))":
     dependencies:
       "@ampproject/remapping": 2.3.0
       "@bcoe/v8-coverage": 1.0.2
@@ -7375,49 +7356,49 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2)
+      vitest: 3.2.6(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  "@vitest/expect@3.2.4":
+  "@vitest/expect@3.2.6":
     dependencies:
       "@types/chai": 5.2.3
-      "@vitest/spy": 3.2.4
-      "@vitest/utils": 3.2.4
+      "@vitest/spy": 3.2.6
+      "@vitest/utils": 3.2.6
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  "@vitest/mocker@3.2.4(vite@7.3.2(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))":
+  "@vitest/mocker@3.2.6(vite@7.3.5(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))":
     dependencies:
-      "@vitest/spy": 3.2.4
+      "@vitest/spy": 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.5(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
-  "@vitest/pretty-format@3.2.4":
+  "@vitest/pretty-format@3.2.6":
     dependencies:
       tinyrainbow: 2.0.0
 
-  "@vitest/runner@3.2.4":
+  "@vitest/runner@3.2.6":
     dependencies:
-      "@vitest/utils": 3.2.4
+      "@vitest/utils": 3.2.6
       pathe: 2.0.3
       strip-literal: 3.1.0
 
-  "@vitest/snapshot@3.2.4":
+  "@vitest/snapshot@3.2.6":
     dependencies:
-      "@vitest/pretty-format": 3.2.4
+      "@vitest/pretty-format": 3.2.6
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  "@vitest/spy@3.2.4":
+  "@vitest/spy@3.2.6":
     dependencies:
       tinyspy: 4.0.4
 
-  "@vitest/utils@3.2.4":
+  "@vitest/utils@3.2.6":
     dependencies:
-      "@vitest/pretty-format": 3.2.4
+      "@vitest/pretty-format": 3.2.6
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
@@ -8200,7 +8181,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.0.33
+      tmp: 0.2.7
 
   extract-zip@2.0.1:
     dependencies:
@@ -8683,7 +8664,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.19.0
+      ws: 8.21.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -8774,7 +8755,7 @@ snapshots:
       speedline-core: 1.4.3
       third-party-web: 0.26.7
       tldts-icann: 6.1.86
-      ws: 7.5.10
+      ws: 7.5.11
       yargs: 17.7.2
       yargs-parser: 21.1.1
     transitivePeerDependencies:
@@ -9109,8 +9090,6 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
-  os-tmpdir@1.0.2: {}
-
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -9270,7 +9249,7 @@ snapshots:
       devtools-protocol: 0.0.1566079
       typed-query-selector: 2.12.1
       webdriver-bidi-protocol: 0.4.1
-      ws: 8.19.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -9352,10 +9331,6 @@ snapshots:
       signal-exit: 4.1.0
 
   rfdc@1.4.1: {}
-
-  rimraf@2.7.1:
-    dependencies:
-      glob: 7.2.3
 
   rimraf@3.0.2:
     dependencies:
@@ -9707,13 +9682,7 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
-
-  tmp@0.1.0:
-    dependencies:
-      rimraf: 2.7.1
+  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -9813,7 +9782,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.5(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
     transitivePeerDependencies:
       - "@types/node"
       - jiti
@@ -9828,7 +9797,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2):
+  vite@7.3.5(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9843,16 +9812,16 @@ snapshots:
       lightningcss: 1.30.2
       yaml: 2.8.2
 
-  vitest@3.2.4(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2):
+  vitest@3.2.6(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2):
     dependencies:
       "@types/chai": 5.2.3
-      "@vitest/expect": 3.2.4
-      "@vitest/mocker": 3.2.4(vite@7.3.2(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
-      "@vitest/pretty-format": 3.2.4
-      "@vitest/runner": 3.2.4
-      "@vitest/snapshot": 3.2.4
-      "@vitest/spy": 3.2.4
-      "@vitest/utils": 3.2.4
+      "@vitest/expect": 3.2.6
+      "@vitest/mocker": 3.2.6(vite@7.3.5(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      "@vitest/pretty-format": 3.2.6
+      "@vitest/runner": 3.2.6
+      "@vitest/snapshot": 3.2.6
+      "@vitest/spy": 3.2.6
+      "@vitest/utils": 3.2.6
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
@@ -9862,10 +9831,10 @@ snapshots:
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.5(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
       vite-node: 3.2.4(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -9967,9 +9936,9 @@ snapshots:
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
 
-  ws@7.5.10: {}
+  ws@7.5.11: {}
 
-  ws@8.19.0: {}
+  ws@8.21.0: {}
 
   xdg-basedir@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,19 @@
+packages:
+  - .
+
+overrides:
+  basic-ftp: 5.3.1
+  fast-uri: 3.1.2
+  flatted: 3.4.2
+  lodash: 4.18.0
+  lodash-es: 4.18.0
+  "minimatch@<3.1.4": 3.1.4
+  "minimatch@>=9.0.0 <9.0.7": 9.0.7
+  path-to-regexp: 0.1.13
+  "picomatch@<2.3.2": 2.3.2
+  "picomatch@>=4.0.0 <4.0.4": 4.0.4
+  "rollup@<4.59.0": 4.59.0
+  "vite@>=7.1.0 <=7.3.4": 7.3.5
+  "tmp@<0.2.7": 0.2.7
+  "ws@>=7.0.0 <7.5.11": 7.5.11
+  "ws@>=8.0.0 <8.21.0": 8.21.0

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3097,9 +3097,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary
- move pnpm security overrides into pnpm-workspace.yaml so pnpm 10 honors them
- bump direct Vite/Vitest security dependencies
- refresh pnpm and Cargo lockfiles to clear current high/critical audit failures

## Lockfile rationale
The pnpm lockfile changed because pnpm 10 ignores package.json#pnpm.overrides; moving the overrides into pnpm-workspace.yaml lets pnpm apply the intended security pins and regenerates the dependency graph. The Cargo lockfile changed only to update quinn-proto from 0.11.14 to 0.11.15 for RUSTSEC-2026-0185.

## Verification
- pnpm audit --audit-level=high --json
- pnpm preflight:ci
- pnpm version:check
- pnpm lint
- pnpm typecheck
- pnpm test:coverage
- pnpm build
- cargo audit (from src-tauri)
- CARGO_TARGET_DIR=/tmp/earthpulse-cargo-target cargo test --manifest-path src-tauri/Cargo.toml

## Notes
This PR unblocks the red security-quality baseline that was preventing Dependabot PRs from going green.