### PR TITLE
fix: unblock dependency security gates

### DIFF
--- a/scripts/git/guard-branch.sh
+++ b/scripts/git/guard-branch.sh
@@ -14,6 +14,10 @@ if [[ "$branch" == "main" || "$branch" == "master" ]]; then
   exit 1
 fi
 
+if [[ "$branch" == dependabot/* ]]; then
+  exit 0
+fi
+
 if ! [[ "$branch" =~ $pattern ]]; then
   echo "Invalid branch: $branch"
   echo "Expected: codex/<type>/<slug>"

--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -1,0 +1,8 @@
+[advisories]
+ignore = [
+  # plist 1.8.0 constrains quick-xml below the fixed 0.41.0 release through Tauri.
+  # Keep this scoped to the two quick-xml advisories and remove it once Tauri/plist
+  # can resolve quick-xml >= 0.41.0.
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
+]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"
@@ -910,7 +910,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "log",
- "quick-xml 0.37.5",
+ "quick-xml 0.41.0",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",
@@ -3058,21 +3058,21 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -3104,7 +3104,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3178,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4359,7 +4359,7 @@ checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
 dependencies = [
  "log",
  "notify-rust",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4473,11 +4473,10 @@ dependencies = [
 
 [[package]]
 name = "tauri-winrt-notification"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
 dependencies = [
- "quick-xml 0.37.5",
  "thiserror 2.0.18",
  "windows",
  "windows-version",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,5 +26,5 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 chrono = { version = "0.4", features = ["serde"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 tokio = { version = "1", features = ["full"] }
-quick-xml = { version = "0.37", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 sgp4 = "2"

--- a/src-tauri/src/fetchers/gdacs.rs
+++ b/src-tauri/src/fetchers/gdacs.rs
@@ -1,5 +1,6 @@
 use super::http::{send_with_resilience, SourceClass, HTTP_CLIENT};
 use crate::models::gdacs::GdacsAlert;
+use quick_xml::escape::unescape;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 
@@ -67,7 +68,11 @@ fn parse_gdacs_rss(xml: &str) -> Result<Vec<GdacsAlert>, String> {
                     continue;
                 }
 
-                let text = e.unescape().unwrap_or_default().to_string();
+                let text = e
+                    .decode()
+                    .ok()
+                    .and_then(|text| unescape(&text).ok().map(|text| text.into_owned()))
+                    .unwrap_or_default();
                 let text = text.trim().to_string();
                 if text.is_empty() {
                     buf.clear();

--- a/src-tauri/src/fetchers/volcano.rs
+++ b/src-tauri/src/fetchers/volcano.rs
@@ -1,5 +1,6 @@
 use super::http::{send_with_resilience, SourceClass, HTTP_CLIENT};
 use crate::models::volcano::Volcano;
+use quick_xml::escape::unescape;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use std::collections::BTreeMap;
@@ -200,7 +201,11 @@ fn parse_weekly_report_rss(xml: &str) -> Result<Vec<Volcano>, String> {
                     continue;
                 }
 
-                let text = e.unescape().unwrap_or_default().to_string();
+                let text = e
+                    .decode()
+                    .ok()
+                    .and_then(|text| unescape(&text).ok().map(|text| text.into_owned()))
+                    .unwrap_or_default();
                 let trimmed = text.trim();
                 if trimmed.is_empty() {
                     buf.clear();


### PR DESCRIPTION
## Summary
- allow Dependabot update branches through the repo branch-name guard
- upgrade direct quick-xml usage to the fixed 0.41 series
- add a scoped cargo-audit ignore for Tauri/plist-constrained quick-xml advisories
- update RSS parser text handling for quick-xml 0.41

## Verification
- cargo check --manifest-path src-tauri/Cargo.toml
- (cd src-tauri && cargo audit)
- GITHUB_HEAD_REF=dependabot/npm_and_yarn/example bash scripts/git/guard-branch.sh
- GITHUB_HEAD_REF=codex/fix/example bash scripts/git/guard-branch.sh
- verified main and feature/foo still fail the guard