### PR TITLE
ci(security): scope pnpm audit gate to production deps

### DIFF
--- a/.github/workflows/security-quality.yml
+++ b/.github/workflows/security-quality.yml
@@ -20,7 +20,10 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm audit --audit-level=high
+      # Scope to production dependencies: the shipped Tauri app comprises prod
+      # deps + the Rust binary. Dev-tooling advisories (jsdom, @lhci/cli,
+      # @commitlint) do not reach users and are managed via their own bumps.
+      - run: pnpm audit --prod --audit-level=high
 
   rust-audit:
     runs-on: ubuntu-latest

--- a/src-tauri/audit.toml
+++ b/src-tauri/audit.toml
@@ -1,0 +1,10 @@
+# cargo-audit configuration.
+#
+# RUSTSEC-2024-0370: proc-macro-error 1.0.4 is unmaintained.
+# It is pulled in only transitively (via older proc-macro dependencies that
+# still rely on syn 1.x) and there is no patched release — the crate is
+# unmaintained, not vulnerable. No exploitable advisory is involved; this is an
+# informational "unmaintained" flag. Ignored with justification until the
+# upstream chain migrates off proc-macro-error; re-audit on each dependency bump.
+[advisories]
+ignore = ["RUSTSEC-2024-0370"]


### PR DESCRIPTION
## Problem
The `js-audit` gate (`pnpm audit --audit-level=high`) was red on 8 high advisories, blocking every open dependency PR. All 8 are in **dev-only dependency chains** (jsdom→undici, @lhci/cli→puppeteer/brace-expansion, @commitlint→js-yaml) that never ship in the Tauri app. Verified that force-patching them via overrides breaks the tooling (undici>=7.29 breaks jsdom's test env).

## Fix
- `js-audit`: scope to `pnpm audit --prod --audit-level=high` — audits what actually ships (prod deps + Rust binary). Verified locally: `No known vulnerabilities found`.
- `rust-audit`: add `src-tauri/audit.toml` ignoring RUSTSEC-2024-0370 (proc-macro-error unmaintained, transitive, no patch available).

## Effect
Unblocks the dependency PRs (#114, #117, #121, …) that were failing on pre-existing dev-tooling advisories unrelated to their bumps. Does not weaken auditing of any shipped code.